### PR TITLE
Nerf Fwagis on L2

### DIFF
--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -115,7 +115,8 @@ regions:
         max-amount: 4
         radius: 40
         max-local-group: 4
-        local-group-radius: 40
+        local-group-radius: 80
+        priority: 0.3
         block-whitelist:
           - WATER
 


### PR DESCRIPTION
In the entrance of the fault (L2 S5) i noticed mases of Fuwagis, like to much, so i modified the spawn valubles.